### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "@types/webfontloader": "^1.6.29",
     "bezier-easing": "^2.1.0",
     "map-or-similar": "^1.5.0",
-    "npm": "^6.9.0",
     "webfontloader": "^1.6.28"
   }
 }


### PR DESCRIPTION

Hello mathiasronimus!

It seems like you have npm as one of your (dev-) dependency in Fluid-Math.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
